### PR TITLE
[FINISHES#128911961] - API - Awesomizer - Add isLength validator

### DIFF
--- a/lib/check.js
+++ b/lib/check.js
@@ -131,7 +131,7 @@ const _isBetweenInc = (min, max) => _.allPass([ _.lte(min), _.gte(max) ])
 
 
 // _isBetween : Int -> Maybe String
-const _isBetween = _.ifElse(
+const _betweenIf = _.ifElse(
   _.identity
 , _.always(null)
 , _.always(MSG.NOT_IN_RANGE)
@@ -140,7 +140,7 @@ const _isBetween = _.ifElse(
 
 // isLength : Int, Int -> (a -> Maybe String)
 const isLength = (min, max) => _.compose(
-  _isBetween
+  _betweenIf
 , _isBetweenInc(min, max)
 , _.length
 )

--- a/lib/check.js
+++ b/lib/check.js
@@ -20,6 +20,7 @@ const MSG  = {
 , LIST_ITEM_NOT_SPEC : 'list_item_not_spec'
 , NOT_NULLABLE       : 'cannot_be_null'
 , IMMUTABLE          : 'cannot_change_immutable'
+, NOT_IN_RANGE       : 'not_in_range'
 };
 
 
@@ -125,6 +126,26 @@ const notReqIfHasAny = _reqIf(_.curryN(2, _.compose(_.not, _.any)))
 const notReqIfHasAll = _reqIf(_.curryN(2, _.compose(_.not, _.all)))
 
 
+// _isInRangeInc : Int, Int -> (Int -> Bool)
+const _isBetweenInc = (min, max) => _.allPass([ _.lte(min), _.gte(max) ])
+
+
+// _isBetween : Int -> Maybe String
+const _isBetween = _.ifElse(
+  _.identity
+, _.always(null)
+, _.always(MSG.NOT_IN_RANGE)
+);
+
+
+// isLength : Int, Int -> (a -> Maybe String)
+const isLength = (min, max) => _.compose(
+  _isBetween
+, _isBetweenInc(min, max)
+, _.length
+)
+
+
 module.exports = {
   MSG
 , extern
@@ -141,4 +162,5 @@ module.exports = {
 , reqIfHasAll
 , notReqIfHasAny
 , notReqIfHasAll
+, isLength
 };

--- a/test/lib/check.spec.js
+++ b/test/lib/check.spec.js
@@ -438,4 +438,54 @@ describe('awesomize/lib/check', () => {
 
   });
 
+  describe('::isLength', () => {
+
+    it(`should return null if value.length is inclusively within range`, () => {
+      const min_edge     = 2;
+      const max_edge     = 5;
+      const min_non_edge = 1;
+      const max_non_edge = 6;
+      const input        = 'abcde';
+
+      const edge     = Check.isLength(min_edge, max_edge)(input)
+      const non_edge = Check.isLength(min_non_edge, max_non_edge)(input)
+
+      expect(edge).to.be.null
+      expect(non_edge).to.be.null
+    });
+
+    it(`should return null if value is empty string`, () => {
+      const min = max = 0;
+      const input     = '';
+
+      const actual = Check.isLength(min, max)(input);
+
+      expect(actual).to.be.null
+    });
+
+    it(`should return Check.MSG.NOT_IN_RANGE if value.length is outise of given
+      bounds`, () => {
+        const min = 2;
+        const max = 5;
+
+        const input_lt_edge = 'a';
+        const input_lt      = '';
+        const input_gt_edge = 'abcdef';
+        const input_gt      = 'abcdefghi';
+
+        const test = Check.isLength(min, max);
+
+        const actual_lt_edge = test(input_lt_edge);
+        const actual_lt      = test(input_lt);
+        const actual_gt_edge = test(input_gt_edge);
+        const actual_gt      = test(input_gt);
+
+        expect(actual_lt_edge).to.be.eql(Check.MSG.NOT_IN_RANGE);
+        expect(actual_lt).to.be.eql(Check.MSG.NOT_IN_RANGE);
+        expect(actual_gt_edge).to.be.eql(Check.MSG.NOT_IN_RANGE);
+        expect(actual_gt).to.be.eql(Check.MSG.NOT_IN_RANGE);
+      });
+
+  });
+
 });


### PR DESCRIPTION
1.  https://www.pivotaltracker.com/story/show/128911961
   * We start our journey through the `isLength` validation check by first visiting the awesomizer's unit tests section. As every developer should know, if you have time start development from unit tests. A short set of positive tests checks if the `isLength` properly returns null for valid input. Those tests cover inputs of length equal to given a minimum and maximum values, as well as lengths a few units away from the boundaries. On the other hand, we test negative cases to assure awesomizer returns `not_in_range` message if variable's length is not covered by given interval.
   * Next on the list is actual implementation of the subject function, `isLength`. `isLength` is a composition of smaller functions: Ramda's `length` function, and auxiliary functions `_isBetweenInc` and `_betweenIf`. The `length` function is self-explanatory. The first helper function checks if a given scalar is equal or within a minimum and maximum values. The last function decides if the evaluated check should return a `null` or a failure message. The failure is very descriptive as `not_in_range`.
   * I wrote this code for one purpose: to validate input to middleware. Awesomizer is missing quite a few validation methods which can be used extensively to protect our databases from bad input.

<img width="234" alt="screen shot 2016-08-23 at 6 10 43 pm" src="https://cloud.githubusercontent.com/assets/6598685/17915144/f7b80e7a-695c-11e6-97b7-9a1021d4db96.png">
